### PR TITLE
Implement logic inference processing for sample data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .DS_Store
+__pycache__/
+*.pyc
+compiled_krb/
+*.log
+scripts/*.sh~

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+scitools-pyke
+nltk
+python-constraint
+func_timeout
+z3-solver
+ply
+tqdm

--- a/sample_data/sample_output.json
+++ b/sample_data/sample_output.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "001",
+    "context": "test_context",
+    "question": "test_question",
+    "option": [
+      "option_test_string_1",
+      "option_test_string_2",
+      "option_test_string_3",
+      "option_test_string_4"
+    ],
+    "answer": "LP: A, FOL: A, CSP: D, SAT: E",
+    "flag_LP": "success",
+    "LP_predicted_answer": "A",
+    "flag_FOL": "success",
+    "FOL_predicted_answer": "A",
+    "flag_CSP": "success",
+    "CSP_predicted_answer": "D",
+    "flag_SAT": "parsing error",
+    "SAT_predicted_answer": "E"
+  },
+  {
+    "id": "002",
+    "context": "test_context",
+    "question": "test_question",
+    "option": [
+      "option_test_string_1",
+      "option_test_string_2",
+      "option_test_string_3",
+      "option_test_string_4"
+    ],
+    "answer": "LP: A, FOL: A, CSP: D, SAT: E",
+    "flag_LP": "success",
+    "LP_predicted_answer": "A",
+    "flag_FOL": "success",
+    "FOL_predicted_answer": "A",
+    "flag_CSP": "success",
+    "CSP_predicted_answer": "D",
+    "flag_SAT": "parsing error",
+    "SAT_predicted_answer": "A"
+  }
+]

--- a/scripts/run_inference.sh
+++ b/scripts/run_inference.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+python src/logic_inference.py

--- a/src/imp.py
+++ b/src/imp.py
@@ -1,0 +1,4 @@
+import importlib
+
+def reload(module):
+    return importlib.reload(module)

--- a/src/symbolic_solvers/fol_solver/prover9_solver.py
+++ b/src/symbolic_solvers/fol_solver/prover9_solver.py
@@ -1,3 +1,4 @@
+import os
 import re
 from nltk.inference.prover9 import *
 from nltk.sem.logic import NegatedExpression
@@ -5,8 +6,11 @@ from .fol_prover9_parser import Prover9_FOL_Formula
 from .Formula import FOL_Formula
 
 # set the path to the prover9 executable
-# os.environ['PROVER9'] = '../Prover9/bin'
-os.environ['PROVER9'] = './models/symbolic_solvers/Prover9/bin'
+# the prover9 binaries are shipped with this repository under
+# `src/symbolic_solvers/Prover9/bin`.  We resolve the absolute path here to
+# avoid issues with the working directory when invoking the solver.
+PROVER9_PATH = os.path.join(os.path.dirname(__file__), '..', 'Prover9', 'bin')
+os.environ['PROVER9'] = PROVER9_PATH
 
 class FOL_Prover9_Program:
     def __init__(self, logic_program:str, dataset_name = 'FOLIO') -> None:


### PR DESCRIPTION
## Summary
- add requirements for solvers
- create stub `imp.reload` for Pyke compatibility with Python 3.12
- fix Prover9 path resolution
- overhaul `logic_inference.py` to process LP/FOL/CSP/SAT programs from sample input
- add run script and output sample
- ignore caches
- restore helper functions and clean output

## Testing
- `pip install -r requirements.txt`
- `python src/logic_inference.py`


------
https://chatgpt.com/codex/tasks/task_e_685f73351478832e9c526d1e88953c03